### PR TITLE
add apache ssl support for keystone

### DIFF
--- a/.github/workflows/packstack.yml
+++ b/.github/workflows/packstack.yml
@@ -64,5 +64,7 @@ jobs:
     - name: push to quay
       run: |
         docker commit packstack packstack-deployed
+        git_hash=$(git rev-parse --short "$GITHUB_SHA")
         docker tag packstack-deployed quay.io/kubev2v/packstack:latest
+        docker tag packstack-deployed quay.io/kubev2v/packstack:${git_hash}
         docker push quay.io/kubev2v/packstack:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
   /lib/systemd/system/systemd-update-utmp*
 
 RUN dnf update -y
+RUN dnf install 'dnf-command(config-manager)' -y
 RUN dnf config-manager --enable powertools
 RUN dnf install -y centos-release-openstack-yoga
 RUN dnf install -y openstack-packstack net-tools iproute
@@ -24,6 +25,8 @@ RUN systemctl enable sshd
 RUN dnf install python3-dnf-plugin-versionlock -y 
 RUN dnf versionlock libvirt-daemon-8.0.0-10.* libvirt-daemon-config-nwfilter-8.0.0-10.*
 
+# install httpd ssl module 
+RUN dnf install mod_ssl -y
 
 # Copy answer file
 ADD files/packstack.answer /packstack.answer

--- a/files/deploy-packstack.sh
+++ b/files/deploy-packstack.sh
@@ -18,3 +18,4 @@ packstack --answer-file=/packstack.answer
 nova-manage cell_v2 discover_hosts
 
 
+echo "LoadModule socache_shmcb_module  modules/mod_socache_shmcb.so" >> /etc/httpd/conf.modules.d/00-ssl.conf


### PR DESCRIPTION
Packstack installation doesn't support built-in SSL/keystone deployment , so we  add  SSL at the Apache level.
note: internally all the OSP components  still  communicate with  keystone on http/5000 ,  we  add additional secure keystone  on https/5001 -  for external authentication.